### PR TITLE
Remove mismatched parenthesis

### DIFF
--- a/synchronized-dimming.groovy
+++ b/synchronized-dimming.groovy
@@ -84,8 +84,7 @@ def tieLevel(event) {
                 sendNotificationEvent("${event.displayName} set to ${level}, synchronizing ${dimmers.size() - 1} dimmers.")
             }
         }
-
-        def remainingDimmers = (dimmers ?: []).findAll { (it != event.device && it.currentValue("level") as int) != level }
+        def remainingDimmers = (dimmers ?: []).findAll { it != event.device && it.currentValue("level") as int != level }
         if (remainingDimmers) {
             synchronized(this) {
                 deviceQueue << remainingDimmers.collectEntries { ["${it.device.id}": level] }


### PR DESCRIPTION
findAll would find everything because the parenthesis were mismatched (so it was comparing everything != level).